### PR TITLE
Limit port range

### DIFF
--- a/webserv/inc/ConfigParser.hpp
+++ b/webserv/inc/ConfigParser.hpp
@@ -96,17 +96,9 @@ class ConfigParser
         void    validateLocationConfig(LocationConfig* currentLocationConfig);
         void    validateServerConfig(ServerConfig* currentServerConfig);
         
-
-
+        
         uint32_t    extractIp(std::istringstream& iss);
         uint16_t    extractPort(std::istringstream& iss);
-        uint32_t    ipStringToNumber(const std::string& ip);
-        uint16_t    ip_port_to_uint16(const std::string& ip_port) ;
-        std::string uint16_to_ip_port(uint16_t port);
-        uint16_t    stringToUint16(const std::string& str);
-
-
-
 
         typedef void (ConfigParser::*HandlerFunction)(void);
         void        validateAndHandleKey(void);

--- a/webserv/inc/ConfigParser.hpp
+++ b/webserv/inc/ConfigParser.hpp
@@ -97,6 +97,9 @@ class ConfigParser
         void    validateServerConfig(ServerConfig* currentServerConfig);
         
 
+
+        uint32_t    extractIp(std::istringstream& iss);
+        uint16_t    extractPort(std::istringstream& iss);
         uint32_t    ipStringToNumber(const std::string& ip);
         uint16_t    ip_port_to_uint16(const std::string& ip_port) ;
         std::string uint16_to_ip_port(uint16_t port);

--- a/webserv/src/config_files/default.conf
+++ b/webserv/src/config_files/default.conf
@@ -4,7 +4,47 @@ server
     server_name: localhost;
 	error_page: 404 error_pages/404.html;
 
-	listen:    127.0.0.1:8081;
+	listen:   127.0.0.1:8080;
+							
+	location /
+	{
+		root: /home/user/Documents/WebserV/webserv/var;
+		index: index.html;
+		cgi_extension: .py .sh;
+
+		upload_store:	 	 upload;
+		allow_methods: GET;
+		autoindex: on;
+	}
+}
+
+server
+{							
+	client_max_body_size: 100000;
+    server_name: localhost;
+	error_page: 404 error_pages/404.html;
+
+	listen:   8080;
+							
+	location /
+	{
+		root: /home/user/Documents/WebserV/webserv/var;
+		index: index.html;
+		cgi_extension: .py .sh;
+
+		upload_store:	 	 upload;
+		allow_methods: GET;
+		autoindex: on;
+	}
+}
+
+server
+{							
+	client_max_body_size: 100000;
+    server_name: localhost;
+	error_page: 404 error_pages/404.html;
+
+	listen:   8080;
 							
 	location /
 	{

--- a/webserv/src/config_files/default.conf
+++ b/webserv/src/config_files/default.conf
@@ -24,7 +24,7 @@ server
     server_name: localhost;
 	error_page: 404 error_pages/404.html;
 
-	listen:   8080;
+	listen:   127.0.0.1:8080;
 							
 	location /
 	{

--- a/webserv/src/config_files/default.conf
+++ b/webserv/src/config_files/default.conf
@@ -1,41 +1,19 @@
-client_max_body_size: 100000;
-
 server
 {							
 	client_max_body_size: 100000;
     server_name: localhost;
 	error_page: 404 error_pages/404.html;
 
-	listen:    127.1.0.1:8081;
+	listen:    127.0.0.1:49152;
 							
 	location /
 	{
-		root: /var;
+		root: /home/user/Documents/WebserV/webserv/var;
 		index: index.html;
 		cgi_extension: .py .sh;
 
 		upload_store:	 	 upload;
 		allow_methods: GET;
 		autoindex: on;
-	}
-}
-
-server
-{							
-	client_max_body_size: 100000;
-    server_name: localhost;
-	error_page: 404 error_pages/404.html;
-
-	listen:    127.1.0.1:8082;
-							
-	location /
-	{
-		root: src;
-		index: index.html;
-		cgi_extension: .py .sh;
-
-		upload_store:	 	 upload;
-		allow_methods: ;
-		autoindex: off;
 	}
 }

--- a/webserv/src/config_files/default.conf
+++ b/webserv/src/config_files/default.conf
@@ -4,7 +4,7 @@ server
     server_name: localhost;
 	error_page: 404 error_pages/404.html;
 
-	listen:    127.0.0.1:49152;
+	listen:    127.0.0.1:8081;
 							
 	location /
 	{

--- a/webserv/src/server/config_parser/ConfigParser.cpp
+++ b/webserv/src/server/config_parser/ConfigParser.cpp
@@ -341,6 +341,10 @@ void	ConfigParser::handleStateValue(char c) // state 4
 	{
 		handleKeyValuePair();
 	}
+	else if (isCommentStart(c))
+	{
+		throwConfigError("Missing semicolon", c, "", true);
+	}
 	else if (toggleQuoteMode(c))
 	{
 		return;
@@ -366,7 +370,8 @@ void	ConfigParser::handleStateValue(char c) // state 4
 
 void	ConfigParser::handleKeyValuePair(void)
 {
-	mulitValues.push_back(value);
+	if (!value.empty())
+		mulitValues.push_back(value);
 	validateAndHandleKey();
 	paramterLength = 0;
 	key.clear();
@@ -440,13 +445,7 @@ void    ConfigParser::validateLocationConfig(LocationConfig* currentLocationConf
 
 void    ConfigParser::validateServerConfig(ServerConfig* currentServerConfig)
 {
-	if (currentServerConfig->ipAddress == 0 || currentServerConfig->port == 0) {        
-       throw std::runtime_error("Error: Server has no valid Ip adress or port\n");
-    }
-	if (currentServerConfig->serverNames.empty()) {
-        std::cout << "Set is empty. Adding 'localhost'." << std::endl;
-        currentServerConfig->serverNames.insert("localhost");
-	}
+	(void)currentServerConfig;
 }
 
 WebServerConfig* ConfigParser::getWebServerConfig(void) const

--- a/webserv/src/server/config_parser/validateValues.cpp
+++ b/webserv/src/server/config_parser/validateValues.cpp
@@ -297,26 +297,3 @@ void    ConfigParser::handleAutoindex()
 	else
 		throwConfigError("autoindex must be on or off", 0, autoIndex, true);
 }
-
-
-
-
-//////////////////////// converters Ip adress and port to UintXX_t and back ///////////////////////////
-
-// std::string ConfigParser::uint16_to_ip_port(uint16_t port) {
-//    std::stringstream ss;
-//    ss  << std::to_string(port);
-
-//    return ss.str();
-// }
-
-uint16_t ConfigParser::stringToUint16(const std::string& str) {
-    std::stringstream ss(str);
-    uint16_t result = 0;
-
-    if (!(ss >> result)) {
-        std::cerr << "Error: Unable to convert string to uint16_t." << std::endl;
-        return 0;
-    }
-    return result;
-}

--- a/webserv/src/server/config_parser/validateValues.cpp
+++ b/webserv/src/server/config_parser/validateValues.cpp
@@ -111,23 +111,15 @@ void	ConfigParser::handleListen()
 
 void	ConfigParser::handleServerName()
 {
-    if (mulitValues.empty()) {
-        	
-			mulitValues.push_back("localhost");
-    }
-    // std::string& serverName = mulitValues[0];	
-	for (std::vector<std::string>::iterator it = mulitValues.begin(); it != mulitValues.end(); ++it) {
-		const std::string& serverName = *it;
-		if (serverName.empty())	{
-			currentServerConfig->serverNames.insert("localhost");
-			break;
-		} else {
-			currentServerConfig->serverNames.insert(serverName);
-		}
+	for (std::vector<std::string>::iterator it = mulitValues.begin(); it != mulitValues.end(); ++it)
+	{
+		std::string& serverName = *it;
+		currentServerConfig->serverNames.insert(serverName);
 	}
 	// /* Print: */
-	// for (std::set<std::string>::iterator it = currentServerConfig->serverNames.begin(); it != currentServerConfig->serverNames.end(); ++it) {
-    //     std::cout << GREEN << "serverName " << *it << RESET << std::endl;
+	// for (std::set<std::string>::iterator it = currentServerConfig->serverNames.begin(); it != currentServerConfig->serverNames.end(); ++it)
+	// {
+    //     	std::cout << GREEN << "serverName " << *it << RESET << std::endl;
 	// }
 }
 

--- a/webserv/src/server/config_parser/validateValues.cpp
+++ b/webserv/src/server/config_parser/validateValues.cpp
@@ -336,8 +336,8 @@ uint16_t ConfigParser::ip_port_to_uint16(const std::string &ip_port)
 	std::istringstream ss(port_str);
 	int port_int = 0;
 	ss >> port_int;
-	if (ss.fail() || (port_int < 49152 && port_int != 80) || port_int > 65535)
-		throw std::runtime_error("Error: Invalid port number. Valid range: 49152 - 65535 && 80");
+	if (ss.fail() || port_int < 0 || port_int > 65535)
+		throw std::runtime_error("Error: Invalid port number. Valid range: 0 - 65535");
 
 	return static_cast<uint16_t>(port_int);
 }

--- a/webserv/src/server/config_parser/validateValues.cpp
+++ b/webserv/src/server/config_parser/validateValues.cpp
@@ -323,18 +323,23 @@ uint32_t ConfigParser::ipStringToNumber(const std::string& ip) {
    return ipv4;
 }
 
-uint16_t ConfigParser::ip_port_to_uint16(const std::string& ip_port) {
-   std::size_t pos = ip_port.find(':');
-   if (pos == std::string::npos) {
-       throw std::invalid_argument("Error: Invalid IP:port format");
-   }
+uint16_t ConfigParser::ip_port_to_uint16(const std::string &ip_port)
+{
+	std::size_t pos = ip_port.find(':');
+	if (pos == std::string::npos)
+		throw std::runtime_error("Error: Invalid IP:port format");
 
-   std::string port_str = ip_port.substr(pos + 1);
-	if(port_str.empty())
-		throw std::invalid_argument("Error: Invalid IP:port format");
-   uint16_t port = static_cast<uint16_t>(std::atoi(port_str.c_str())); //check for correct error handling
-	
-   return port;
+	std::string port_str = ip_port.substr(pos + 1);
+	if (port_str.empty())
+		throw std::runtime_error("Error: Invalid IP:port format");
+
+	std::istringstream ss(port_str);
+	int port_int = 0;
+	ss >> port_int;
+	if (ss.fail() || (port_int < 49152 && port_int != 80) || port_int > 65535)
+		throw std::runtime_error("Error: Invalid port number. Valid range: 49152 - 65535 && 80");
+
+	return static_cast<uint16_t>(port_int);
 }
 
 // std::string ConfigParser::uint16_to_ip_port(uint16_t port) {


### PR DESCRIPTION
All valid port numbers are allowed 0 - 65535.
Ports that are already taken wont start since only one socket can bind to it. (configured this way in standard).
You can start the server with multiple server blocks of the same ip address and port since you can specify with server_names which one answers.
Also the first one will be the default one.
